### PR TITLE
Security: Dependabot findings.

### DIFF
--- a/.github/workflows/build.from.developer.branch.deploy.to.dev.yml
+++ b/.github/workflows/build.from.developer.branch.deploy.to.dev.yml
@@ -63,7 +63,7 @@ jobs:
           echo "TAG=latest ${GITHUB_SHA::12}" | tee -a $GITHUB_ENV
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ${{ vars.DOCKER_ARTIFACTORY_REPO }}
           username: ${{ vars.DOCKER_ARTIFACTORY_USERNAME }}

--- a/.github/workflows/build.from.main.branch.deploy.to.dev.yml
+++ b/.github/workflows/build.from.main.branch.deploy.to.dev.yml
@@ -49,7 +49,7 @@ jobs:
           echo "TAG=latest ${GITHUB_SHA::12}" | tee -a $GITHUB_ENV
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ${{ vars.DOCKER_ARTIFACTORY_REPO }}
           username: ${{ vars.DOCKER_ARTIFACTORY_USERNAME }}

--- a/.github/workflows/build.from.release.branch.deploy.to.dev.yml
+++ b/.github/workflows/build.from.release.branch.deploy.to.dev.yml
@@ -58,7 +58,7 @@ jobs:
           echo "TAG=latest ${GITHUB_SHA::12}" | tee -a $GITHUB_ENV
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ${{ vars.DOCKER_ARTIFACTORY_REPO }}
           username: ${{ vars.DOCKER_ARTIFACTORY_USERNAME }}

--- a/.github/workflows/on.pr.yml
+++ b/.github/workflows/on.pr.yml
@@ -21,8 +21,9 @@ jobs:
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
       - name: Set up JDK 18
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
+          distribution: 'corretto'
           java-version: 18
       - uses: actions/cache@v1
         with:
@@ -42,7 +43,7 @@ jobs:
           severity: 'CRITICAL'
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: 'trivy-results.sarif'
       - name: Cache SonarCloud packages

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -24,11 +24,11 @@
 			src/main/java/ca/bc/gov/educ/api/ruleengine/util/**
 		</sonar.exclusions>
 		<java.version>18</java.version>
-		<maven.compiler.version>3.10.1</maven.compiler.version>
+		<maven.compiler.version>3.13.0</maven.compiler.version>
 		<maven.compiler.source>${java.version}</maven.compiler.source>
 		<maven.compiler.target>${java.version}</maven.compiler.target>
 		<junit>4.12</junit>
-		<log4j.version>2.18.0</log4j.version>
+		<log4j.version>2.24.3</log4j.version>
 	</properties>
 
 	<dependencies>
@@ -56,7 +56,8 @@
 		</dependency>
 		<dependency>
 			<groupId>com.oracle.database.jdbc</groupId>
-			<artifactId>ojdbc8</artifactId>
+			<artifactId>ojdbc11</artifactId>
+			<version>23.6.0.24.10</version>
 			<scope>runtime</scope>
 		</dependency>
 		<dependency>
@@ -83,7 +84,7 @@
 		<dependency>
 			<groupId>org.modelmapper</groupId>
 			<artifactId>modelmapper</artifactId>
-			<version>3.1.0</version>
+			<version>3.2.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -115,7 +116,7 @@
          <dependency>
 		    <groupId>commons-io</groupId>
 		    <artifactId>commons-io</artifactId>
-		    <version>2.11.0</version>
+		    <version>2.18.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
@@ -213,7 +214,7 @@
 					<plugin>
 						<groupId>org.hibernate.orm.tooling</groupId>
 						<artifactId>hibernate-enhance-maven-plugin</artifactId>
-						<version>6.1.1.Final</version>
+						<version>6.6.5.Final</version>
 						<executions>
 							<execution>
 								<configuration>


### PR DESCRIPTION

Change Details:

- Bump org.hibernate.orm.tooling:hibernate-enhance-maven-plugin from 6.1.1.Final to 6.6.5.Final  
- Bump org.modelmapper:modelmapper from 3.1.0 to 3.2.2  
- Bump org.apache.maven.plugins:maven-compiler-plugin from 3.10.1 to 3.13.0  
- Bump github/codeql-action from 2 to 3 
- Bump actions/setup-java from 1 to 4 
- Bump docker/login-action from 2 to 3 
- Bump log4j.version from 2.18.0 to 2.20.0 to 2.24.3 
- Upgrade ojdbc8 to ojdbc11
- Bump commons-io:commons-io from 2.7 to 2.18.0 